### PR TITLE
feat: refresh wedding palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -13,7 +13,7 @@
     color: #333333;
     overflow-x: hidden;
     font-family: var(--font-montserrat), sans-serif;
-    background-color: #7c9070;
+    background-color: #a9c4dd;
   }
 
   h1,
@@ -45,7 +45,7 @@
     align-items: center;
     justify-content: center;
     padding: 1rem;
-    background: linear-gradient(135deg, #7c9070 0%, #7c9070 100%);
+    background: linear-gradient(135deg, #a9c4dd 0%, #a9c4dd 100%);
   }
 
   .envelope-shadow {
@@ -61,11 +61,11 @@
   }
 
   .gold-gradient {
-    background: linear-gradient(135deg, #d4a574 0%, #d4a574 100%);
+    background: linear-gradient(135deg, #F7E7CE 0%, #F7E7CE 100%);
   }
 
   .navy-gradient {
-    background: linear-gradient(135deg, #7c9070 0%, #7c9070 100%);
+    background: linear-gradient(135deg, #a9c4dd 0%, #a9c4dd 100%);
   }
 }
 
@@ -73,11 +73,11 @@
 
   /* Colores de wedding unificados */
   .text-wedding-olive {
-    color: #7c9070;
+    color: #a9c4dd;
   }
 
   .text-wedding-gold {
-    color: #d4a574;
+    color: #F7E7CE;
   }
 
   .text-wedding-cream {
@@ -85,11 +85,11 @@
   }
 
   .bg-wedding-olive {
-    background-color: #7c9070;
+    background-color: #a9c4dd;
   }
 
   .bg-wedding-gold {
-    background-color: #d4a574;
+    background-color: #F7E7CE;
   }
 
   .bg-wedding-cream {
@@ -98,11 +98,11 @@
 
   /* Bordes sólidos */
   .border-wedding-olive {
-    border-color: #7c9070;
+    border-color: #a9c4dd;
   }
 
   .border-wedding-gold {
-    border-color: #d4a574;
+    border-color: #F7E7CE;
   }
 
   .border-wedding-cream {
@@ -111,23 +111,23 @@
 
   /* Colores con transparencias */
   .text-wedding-olive\/80 {
-    color: rgba(124, 144, 112, 0.8);
+    color: rgba(169, 196, 221, 0.8);
   }
 
   .text-wedding-olive\/70 {
-    color: rgba(124, 144, 112, 0.7);
+    color: rgba(169, 196, 221, 0.7);
   }
 
   .text-wedding-olive\/60 {
-    color: rgba(124, 144, 112, 0.6);
+    color: rgba(169, 196, 221, 0.6);
   }
 
   .text-wedding-gold\/90 {
-    color: rgba(212, 165, 116, 0.9);
+    color: rgba(247, 231, 206, 0.9);
   }
 
   .text-wedding-gold\/80 {
-    color: rgba(212, 165, 116, 0.8);
+    color: rgba(247, 231, 206, 0.8);
   }
 
   .text-wedding-cream\/90 {
@@ -144,23 +144,23 @@
 
   /* Fondos con transparencias */
   .bg-wedding-olive\/95 {
-    background-color: rgba(124, 144, 112, 0.95);
+    background-color: rgba(169, 196, 221, 0.95);
   }
 
   .bg-wedding-olive\/20 {
-    background-color: rgba(124, 144, 112, 0.2);
+    background-color: rgba(169, 196, 221, 0.2);
   }
 
   .bg-wedding-olive\/10 {
-    background-color: rgba(124, 144, 112, 0.1);
+    background-color: rgba(169, 196, 221, 0.1);
   }
 
   .bg-wedding-gold\/20 {
-    background-color: rgba(212, 165, 116, 0.2);
+    background-color: rgba(247, 231, 206, 0.2);
   }
 
   .bg-wedding-gold\/10 {
-    background-color: rgba(212, 165, 116, 0.1);
+    background-color: rgba(247, 231, 206, 0.1);
   }
 
   .bg-wedding-cream\/90 {
@@ -177,28 +177,28 @@
 
   /* Bordes con transparencias */
   .border-wedding-gold\/20 {
-    border-color: rgba(212, 165, 116, 0.2);
+    border-color: rgba(247, 231, 206, 0.2);
   }
 
   .border-wedding-gold\/30 {
-    border-color: rgba(212, 165, 116, 0.3);
+    border-color: rgba(247, 231, 206, 0.3);
   }
 
   .border-wedding-olive\/20 {
-    border-color: rgba(124, 144, 112, 0.2);
+    border-color: rgba(169, 196, 221, 0.2);
   }
 
   /* Utilidades de líneas/divisores */
   .bg-wedding-gold\/50 {
-    background-color: rgba(212, 165, 116, 0.5);
+    background-color: rgba(247, 231, 206, 0.5);
   }
 
   .bg-wedding-gold\/40 {
-    background-color: rgba(212, 165, 116, 0.4);
+    background-color: rgba(247, 231, 206, 0.4);
   }
 
   .bg-wedding-gold\/30 {
-    background-color: rgba(212, 165, 116, 0.3);
+    background-color: rgba(247, 231, 206, 0.3);
   }
 
   /* Border left personalizado */
@@ -306,16 +306,16 @@
 }
 
 ::-webkit-scrollbar-track {
-  background: #7c9070;
+  background: #a9c4dd;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #d4a574;
+  background: #F7E7CE;
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: #d4a574;
+  background: #F7E7CE;
 }
 
 /* Print styles */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,7 +59,7 @@ export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
   maximumScale: 1,
-  themeColor: "#7c9070",
+  themeColor: "#a9c4dd",
 };
 
 export default function RootLayout({
@@ -72,7 +72,7 @@ export default function RootLayout({
       lang="es"
       className={`${greatVibes.variable} ${montserrat.variable} ${playfairDisplay.variable}`}
     >
-      <body className="bg-[#7c9070] antialiased">
+      <body className="bg-[#a9c4dd] antialiased">
         <MusicProvider>
           <InvitationProvider>
             <main className="min-h-screen">{children}</main>

--- a/src/components/EnvelopeInvitation/EnvelopeInvitation.module.css
+++ b/src/components/EnvelopeInvitation/EnvelopeInvitation.module.css
@@ -133,18 +133,18 @@
     width: 100%;
     padding: 14px 24px;
     background: linear-gradient(135deg,
-            #7c9070 0%,
-            #8fa082 25%,
-            #9fb094 50%,
-            #8fa082 75%,
-            #7c9070 100%);
+            #7f95b3 0%,
+            #8fb1ce 25%,
+            #a9c4dd 50%,
+            #b7d2e5 75%,
+            #cdd9e7 100%);
     border-radius: 35px;
     border: none;
     cursor: pointer;
     transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
     box-shadow:
-        0 6px 20px rgba(124, 144, 112, 0.4),
-        0 3px 12px rgba(124, 144, 112, 0.3),
+        0 6px 20px rgba(169, 196, 221, 0.4),
+        0 3px 12px rgba(169, 196, 221, 0.3),
         inset 0 1px 0 rgba(255, 255, 255, 0.2);
     position: relative;
     overflow: hidden;
@@ -190,8 +190,8 @@
 .mainButton:hover {
     transform: translateY(-3px) scale(1.02);
     box-shadow:
-        0 12px 35px rgba(124, 144, 112, 0.5),
-        0 6px 20px rgba(124, 144, 112, 0.4),
+        0 12px 35px rgba(169, 196, 221, 0.5),
+        0 6px 20px rgba(169, 196, 221, 0.4),
         inset 0 1px 0 rgba(255, 255, 255, 0.3);
 }
 
@@ -210,15 +210,15 @@
     100% {
         transform: scale(1);
         box-shadow:
-            0 6px 20px rgba(124, 144, 112, 0.4),
-            0 3px 12px rgba(124, 144, 112, 0.3);
+            0 6px 20px rgba(169, 196, 221, 0.4),
+            0 3px 12px rgba(169, 196, 221, 0.3);
     }
 
     50% {
         transform: scale(1.05);
         box-shadow:
-            0 10px 30px rgba(124, 144, 112, 0.5),
-            0 5px 18px rgba(124, 144, 112, 0.4);
+            0 10px 30px rgba(169, 196, 221, 0.5),
+            0 5px 18px rgba(169, 196, 221, 0.4);
     }
 }
 

--- a/src/components/EnvelopeInvitation/EnvelopeInvitation.tsx
+++ b/src/components/EnvelopeInvitation/EnvelopeInvitation.tsx
@@ -168,7 +168,7 @@ const EnvelopeInvitation: React.FC = () => {
                         height="20"
                         viewBox="0 0 24 24"
                         fill="currentColor"
-                        className="text-wedding-cream animate-pulse"
+                        className="text-wedding-gold animate-pulse"
                       >
                         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
                       </svg>
@@ -177,12 +177,12 @@ const EnvelopeInvitation: React.FC = () => {
                         height="20"
                         viewBox="0 0 24 24"
                         fill="currentColor"
-                        className="text-wedding-cream animate-pulse delay-200 -ml-2"
+                        className="text-wedding-gold animate-pulse delay-200 -ml-2"
                       >
                         <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
                       </svg>
                     </div>
-                    <span className="text-wedding-cream font-sans font-semibold text-sm md:text-base">
+                    <span className="text-wedding-gold font-sans font-semibold text-sm md:text-base">
                       Abrir Invitación
                     </span>
                   </div>

--- a/src/components/GenerateQRUrl/GenerateQRUrl.tsx
+++ b/src/components/GenerateQRUrl/GenerateQRUrl.tsx
@@ -46,7 +46,7 @@ export const QRPhotoSection: React.FC<{
       {/* Instrucciones */}
       <div className="space-y-4 text-left max-w-md mx-auto">
         <div className="flex items-start gap-3">
-          <span className="flex-shrink-0 w-6 h-6 bg-wedding-gold text-white rounded-full flex items-center justify-center text-sm font-bold">
+          <span className="flex-shrink-0 w-6 h-6 bg-wedding-olive text-wedding-gold rounded-full flex items-center justify-center text-sm font-bold">
             1
           </span>
           <p className="text-sm text-wedding-olive">
@@ -55,7 +55,7 @@ export const QRPhotoSection: React.FC<{
         </div>
 
         <div className="flex items-start gap-3">
-          <span className="flex-shrink-0 w-6 h-6 bg-wedding-gold text-white rounded-full flex items-center justify-center text-sm font-bold">
+          <span className="flex-shrink-0 w-6 h-6 bg-wedding-olive text-wedding-gold rounded-full flex items-center justify-center text-sm font-bold">
             2
           </span>
           <p className="text-sm text-wedding-olive">
@@ -64,7 +64,7 @@ export const QRPhotoSection: React.FC<{
         </div>
 
         <div className="flex items-start gap-3">
-          <span className="flex-shrink-0 w-6 h-6 bg-wedding-gold text-white rounded-full flex items-center justify-center text-sm font-bold">
+          <span className="flex-shrink-0 w-6 h-6 bg-wedding-olive text-wedding-gold rounded-full flex items-center justify-center text-sm font-bold">
             3
           </span>
           <p className="text-sm text-wedding-olive">
@@ -89,7 +89,7 @@ export const QRPhotoSection: React.FC<{
       {/* Botón para abrir directamente */}
       <button
         onClick={() => window.open(driveUrl, "_blank")}
-        className="mt-4 px-6 py-2 bg-wedding-gold text-white rounded-lg hover:bg-wedding-gold/90 transition-colors duration-200"
+        className="mt-4 px-6 py-2 bg-gradient-to-r from-wedding-olive-dark to-wedding-olive text-wedding-gold rounded-lg shadow-md hover:shadow-lg transition-all duration-200"
       >
         📁 Abrir carpeta directamente
       </button>

--- a/src/components/InvitationDetails/InvitationDetails.module.css
+++ b/src/components/InvitationDetails/InvitationDetails.module.css
@@ -33,9 +33,9 @@
 }
 
 .navButton.active {
-    background: rgba(212, 165, 116, 0.3);
-    border-color: #d4a574;
-    box-shadow: 0 4px 12px rgba(212, 165, 116, 0.2);
+    background: rgba(247, 231, 206, 0.3);
+    border-color: #F7E7CE;
+    box-shadow: 0 4px 12px rgba(247, 231, 206, 0.2);
 }
 
 .content {
@@ -51,7 +51,7 @@
     box-shadow: 0 10px 40px rgba(0, 0, 0, 0.15);
     animation: slideIn 0.6s ease-out;
     backdrop-filter: blur(8px);
-    border: 1px solid rgba(212, 165, 116, 0.2);
+    border: 1px solid rgba(247, 231, 206, 0.2);
 }
 
 @keyframes slideIn {
@@ -76,7 +76,7 @@
     display: flex;
     flex-direction: column;
     padding: 0.75rem 0;
-    border-bottom: 1px solid rgba(124, 144, 112, 0.1);
+    border-bottom: 1px solid rgba(169, 196, 221, 0.1);
 }
 
 .infoItem:last-child {
@@ -85,7 +85,7 @@
 
 .infoLabel {
     font-size: 0.875rem;
-    color: #d4a574;
+    color: #7f95b3;
     font-weight: 600;
     text-transform: uppercase;
     letter-spacing: 0.5px;
@@ -94,7 +94,7 @@
 
 .infoValue {
     font-size: 1.125rem;
-    color: #7c9070;
+    color: #a9c4dd;
     font-family: 'Montserrat', sans-serif;
     line-height: 1.5;
 }
@@ -106,7 +106,7 @@
     border-radius: 20px;
     padding: 2rem;
     backdrop-filter: blur(8px);
-    border: 1px solid rgba(212, 165, 116, 0.2);
+    border: 1px solid rgba(247, 231, 206, 0.2);
     box-shadow: 0 10px 40px rgba(0, 0, 0, 0.1);
 }
 
@@ -122,7 +122,7 @@
     top: 0;
     bottom: 0;
     width: 2px;
-    background: linear-gradient(180deg, #d4a574 0%, rgba(212, 165, 116, 0.3) 100%);
+    background: linear-gradient(180deg, #a9c4dd 0%, rgba(169, 196, 221, 0.3) 100%);
 }
 
 .timelineItem {
@@ -177,10 +177,10 @@
     top: 4px;
     width: 16px;
     height: 16px;
-    background: #d4a574;
+    background: #a9c4dd;
     border: 3px solid #fdf6f0;
     border-radius: 50%;
-    box-shadow: 0 0 0 3px rgba(212, 165, 116, 0.2);
+    box-shadow: 0 0 0 3px rgba(169, 196, 221, 0.2);
 }
 
 .timelineContent {
@@ -192,12 +192,12 @@
 .timelineTime {
     font-size: 0.875rem;
     font-weight: 600;
-    color: #d4a574;
+    color: #7f95b3;
 }
 
 .timelineEvent {
     font-size: 1rem;
-    color: #7c9070;
+    color: #a9c4dd;
 }
 
 .actions {
@@ -224,26 +224,25 @@
 }
 
 .confirmButton {
-    background: linear-gradient(135deg, #d4a574 0%, #d4a574 100%);
-    color: white;
-    box-shadow: 0 4px 15px rgba(212, 165, 116, 0.3);
+    background: linear-gradient(135deg, #7f95b3 0%, #a9c4dd 100%);
+    color: #F7E7CE;
+    box-shadow: 0 4px 15px rgba(169, 196, 221, 0.3);
 }
 
 .confirmButton:hover {
     transform: translateY(-2px);
-    box-shadow: 0 6px 20px rgba(212, 165, 116, 0.4);
+    box-shadow: 0 6px 20px rgba(169, 196, 221, 0.4);
 }
 
 .mapButton {
-    background: rgba(253, 246, 240, 0.95);
-    color: #7c9070;
-    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.1);
-    border: 1px solid rgba(212, 165, 116, 0.2);
+    background: linear-gradient(135deg, #7f95b3 0%, #a9c4dd 100%);
+    color: #F7E7CE;
+    box-shadow: 0 4px 15px rgba(169, 196, 221, 0.3);
 }
 
 .mapButton:hover {
     transform: translateY(-2px);
-    background: rgba(253, 246, 240, 1);
+    box-shadow: 0 6px 20px rgba(169, 196, 221, 0.4);
 }
 
 .footer {

--- a/src/components/LoadingScreen/LoadingScreen.module.css
+++ b/src/components/LoadingScreen/LoadingScreen.module.css
@@ -38,7 +38,7 @@
     transform: translate(-50%, -50%);
     width: 80px;
     height: 80px;
-    border: 2px solid #d4a574;
+    border: 2px solid #F7E7CE;
     border-radius: 50%;
     animation: pulse 2s ease-out infinite;
     opacity: 0;

--- a/src/components/LoadingScreen/LoadingScreen.tsx
+++ b/src/components/LoadingScreen/LoadingScreen.tsx
@@ -21,7 +21,7 @@ const LoadingScreen: React.FC = () => {
   }, []);
 
   return (
-    <div className="fixed inset-0 bg-[#7c9070] flex flex-col items-center justify-center z-50">
+    <div className="fixed inset-0 bg-[#a9c4dd] flex flex-col items-center justify-center z-50">
       <div className="relative mb-8">
         <div className={styles.heartContainer}>
           <svg
@@ -33,7 +33,7 @@ const LoadingScreen: React.FC = () => {
           >
             <path
               d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"
-              fill="#d4a574"
+              fill="#F7E7CE"
             />
           </svg>
           <div className={styles.pulseRing}></div>
@@ -48,7 +48,7 @@ const LoadingScreen: React.FC = () => {
         Johanna & Enrique
       </h1>
 
-      <p className="text-[#d4a574] text-lg font-sans font-light mb-8">
+      <p className="text-[#F7E7CE] text-lg font-sans font-light mb-8">
         25.10.2025
       </p>
 
@@ -57,7 +57,7 @@ const LoadingScreen: React.FC = () => {
           className="h-full transition-all duration-300 ease-out"
           style={{
             width: `${progress}%`,
-            background: "linear-gradient(to right, #d4a574, #fdf6f0)",
+            background: "linear-gradient(to right, #F7E7CE, #fdf6f0)",
           }}
         />
       </div>

--- a/src/components/shared/FloralDecoration.tsx
+++ b/src/components/shared/FloralDecoration.tsx
@@ -17,7 +17,7 @@ interface FloralDecorationProps {
 const FloralDecoration: React.FC<FloralDecorationProps> = ({
   position = "top-left",
   size = "medium",
-  color = "#d4a574",
+  color = "#F7E7CE",
   opacity = 0.3,
 }) => {
   const getSizeClasses = () => {

--- a/src/components/shared/MusicControlButton.tsx
+++ b/src/components/shared/MusicControlButton.tsx
@@ -78,7 +78,7 @@ const MusicControlButton: React.FC = () => {
               onChange={(e) => setVolume(Number(e.target.value) / 100)}
               className="w-32 h-2 bg-gray-200 rounded-lg appearance-none cursor-pointer slider range-slider"
               style={{
-                background: `linear-gradient(to right, #d4a574 0%, #d4a574 ${
+                background: `linear-gradient(to right, #F7E7CE 0%, #F7E7CE ${
                   volume * 100
                 }%, #e5e5e5 ${volume * 100}%, #e5e5e5 100%)`,
               }}
@@ -90,7 +90,7 @@ const MusicControlButton: React.FC = () => {
                 width: 16px;
                 height: 16px;
                 border-radius: 50%;
-                background: #d4a574;
+                background: #F7E7CE;
                 cursor: pointer;
                 border: 2px solid #ffffff;
                 box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
@@ -100,19 +100,19 @@ const MusicControlButton: React.FC = () => {
                 width: 16px;
                 height: 16px;
                 border-radius: 50%;
-                background: #d4a574;
+                background: #F7E7CE;
                 cursor: pointer;
                 border: 2px solid #ffffff;
                 box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
               }
 
               .range-slider::-webkit-slider-thumb:hover {
-                background: #c89660;
+                background: #e5d2b8;
                 transform: scale(1.1);
               }
 
               .range-slider::-moz-range-thumb:hover {
-                background: #c89660;
+                background: #e5d2b8;
                 transform: scale(1.1);
               }
             `}</style>
@@ -131,7 +131,7 @@ const MusicControlButton: React.FC = () => {
         >
           {isPlaying ? (
             <svg
-              className="w-6 h-6 text-[#7c9070] absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
+              className="w-6 h-6 text-[#a9c4dd] absolute top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2"
               fill="none"
               stroke="currentColor"
               strokeWidth="2"
@@ -156,8 +156,8 @@ const MusicControlButton: React.FC = () => {
 
           {isPlaying && (
             <>
-              <span className="absolute inset-0 rounded-full bg-[#7c9070]/20 animate-ping"></span>
-              <span className="absolute inset-0 rounded-full bg-[#7c9070]/10 animate-ping animation-delay-200"></span>
+              <span className="absolute inset-0 rounded-full bg-[#a9c4dd]/20 animate-ping"></span>
+              <span className="absolute inset-0 rounded-full bg-[#a9c4dd]/10 animate-ping animation-delay-200"></span>
             </>
           )}
         </button>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -10,11 +10,11 @@ const config: Config = {
   theme: {
     extend: {
       colors: {
-        // Paleta de colores personalizada para la boda - Verde Oliva Claro
-        "wedding-olive": "#7c9070", // Verde oliva claro principal
-        "wedding-olive-dark": "#5a6b50", // Verde oliva oscuro
-        "wedding-olive-light": "#a3b899", // Verde oliva muy claro
-        "wedding-gold": "#d4a574", // Dorado
+        // Paleta de colores personalizada para la boda - Azul Pastel
+        "wedding-olive": "#a9c4dd", // Azul pastel principal
+        "wedding-olive-dark": "#7f95b3", // Azul pastel oscuro
+        "wedding-olive-light": "#cdd9e7", // Azul pastel muy claro
+        "wedding-gold": "#F7E7CE", // Dorado suave
         "wedding-cream": "#fdf6f0", // Crema
         "wedding-sage": "#b5c2a9", // Verde salvia claro
         "wedding-white": "#ffffff",


### PR DESCRIPTION
## Summary
- replace lingering green gradient in invitation opener with full pastel blue and gold accents
- update action buttons to use new blue/gold scheme
- use darker blue for timeline time and info labels for better contrast
- switch timeline line and dots to pastel blue and align map button with the new gradient
- recolor photo upload steps and folder button to match pastel blue and gold palette

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b3bd8d6770832cbc8210184c1104e3