### PR TITLE
Improve QR upload instructions and open-folder button style

### DIFF
--- a/src/components/GenerateQRUrl/GenerateQRUrl.tsx
+++ b/src/components/GenerateQRUrl/GenerateQRUrl.tsx
@@ -46,7 +46,7 @@ export const QRPhotoSection: React.FC<{
       {/* Instrucciones */}
       <div className="space-y-4 text-left max-w-md mx-auto">
         <div className="flex items-start gap-3">
-          <span className="flex-shrink-0 w-6 h-6 bg-wedding-gold text-white rounded-full flex items-center justify-center text-sm font-bold">
+          <span className="flex-shrink-0 w-6 h-6 bg-wedding-olive-light text-wedding-gold rounded-full flex items-center justify-center text-sm font-bold">
             1
           </span>
           <p className="text-sm text-wedding-olive">
@@ -55,7 +55,7 @@ export const QRPhotoSection: React.FC<{
         </div>
 
         <div className="flex items-start gap-3">
-          <span className="flex-shrink-0 w-6 h-6 bg-wedding-gold text-white rounded-full flex items-center justify-center text-sm font-bold">
+          <span className="flex-shrink-0 w-6 h-6 bg-wedding-olive-light text-wedding-gold rounded-full flex items-center justify-center text-sm font-bold">
             2
           </span>
           <p className="text-sm text-wedding-olive">
@@ -64,7 +64,7 @@ export const QRPhotoSection: React.FC<{
         </div>
 
         <div className="flex items-start gap-3">
-          <span className="flex-shrink-0 w-6 h-6 bg-wedding-gold text-white rounded-full flex items-center justify-center text-sm font-bold">
+          <span className="flex-shrink-0 w-6 h-6 bg-wedding-olive-light text-wedding-gold rounded-full flex items-center justify-center text-sm font-bold">
             3
           </span>
           <p className="text-sm text-wedding-olive">
@@ -89,7 +89,7 @@ export const QRPhotoSection: React.FC<{
       {/* Botón para abrir directamente */}
       <button
         onClick={() => window.open(driveUrl, "_blank")}
-        className="mt-4 px-6 py-2 bg-wedding-gold text-white rounded-lg hover:bg-wedding-gold/90 transition-colors duration-200"
+        className="mt-4 px-6 py-2 bg-gradient-to-r from-wedding-olive to-wedding-olive-dark text-wedding-gold rounded-lg hover:shadow-lg transition-all duration-200"
       >
         📁 Abrir carpeta directamente
       </button>


### PR DESCRIPTION
## Summary
- switch QR upload step markers to pastel-blue circles with gold numerals
- restyle “📁 Abrir carpeta directamente” button with blue gradient background, gold text, and hover shadow for better visibility

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3ca5ef070832ca6f78cf38f65fd9a